### PR TITLE
Self-contained imports

### DIFF
--- a/src/load.nix
+++ b/src/load.nix
@@ -43,7 +43,7 @@ let
 
   view = { cursor ? [ ], node, pov, transformer }:
     if node.isDir then
-      transformer
+      transformer cursor
         (flip concatMapAttrs node.children
           (name: node: optionalAttrs
             {
@@ -121,7 +121,7 @@ in
 { src
 , loader ? root.loaders.default
 , inputs ? { }
-, transformer ? id
+, transformer ? _: id
 }:
 
 assert all

--- a/src/load.nix
+++ b/src/load.nix
@@ -6,6 +6,7 @@ let
     attrValues
     elemAt
     foldl'
+    isList
     length
     mapAttrs
     match
@@ -122,7 +123,14 @@ in
 , loader ? root.loaders.default
 , inputs ? { }
 , transformer ? _: id
-}:
+}: let
+  transformer' =
+    if isList transformer
+    then (cursor: mod: pipe mod (
+      map (t: t cursor) transformer)
+    )
+    else transformer;
+in
 
 assert all
   (name: inputs ? ${name}
@@ -130,15 +138,16 @@ assert all
   [ "self" "super" "root" ];
 
 view {
-  inherit transformer;
   pov = "external";
+  transformer = transformer';
   node = fix (node: {
     isDir = true;
     children = aggregate {
       inherit src loader inputs;
       tree = {
-        inherit node transformer;
         pov = [ ];
+        transformer = transformer';
+        inherit node;
       };
     };
   });

--- a/src/transformers/hoistImports.nix
+++ b/src/transformers/hoistImports.nix
@@ -1,0 +1,39 @@
+{ lib }:
+
+let
+  inherit (builtins)
+    attrValues
+    length
+    mapAttrs
+    removeAttrs
+    isAttrs
+    catAttrs
+    filter
+    ;
+  inherit (lib)
+    flatten
+    optionalAttrs
+    ;
+
+in
+
+cursor: mod: let
+  toplevel = length cursor == 0;
+  # peek forward one level down if it is an attrs
+  leafattrs = filter isAttrs (attrValues mod);
+  # and collect '_imports' keys where they exists
+  # into a flat list of imports
+  _imports = flatten (catAttrs "_imports" leafattrs);
+  # then remove those just so collected andthereby
+  # complete the "hoist"
+  mod' = mapAttrs (_: v:
+    if v ? _imports
+    then removeAttrs v ["_imports"]
+    else v
+  ) mod;
+in mod'
+# attach the hoisted imports to the current level
+# and if we've reached tho toplevel rename to 'imports'
+# which the module system can understand
+// optionalAttrs (_imports != [] && toplevel) {imports = _imports;}
+// optionalAttrs (_imports != [] && !toplevel) {inherit _imports;}

--- a/src/transformers/liftDefault.nix
+++ b/src/transformers/liftDefault.nix
@@ -6,7 +6,7 @@ let
     ;
 in
 
-mod:
+_: mod:
 
 unionOfDisjoint
   (removeAttrs mod [ "default" ])


### PR DESCRIPTION
Enables capability:
```nix
# ./nix/localRegistry.nix
{qnr}: {
  _imports = [qnr.nixosModules.local-registry];
  # Enable quick-nix-registry
  enable = true;
  # Cache the default nix registry locally, to avoid extraneous registry updates from nix cli.
  cacheGlobalRegistry = true;
  # Set an empty global registry.
  noGlobalRegistry = false;
}
```

I.e. **Self-contained `imports`**