### PR TITLE
[feat] Add support for passing structured content collected by haumea into flake-parts, (in a way that respects perSystem)

### DIFF
--- a/src/loaders/dispatch.nix
+++ b/src/loaders/dispatch.nix
@@ -1,0 +1,98 @@
+# loaders/dispatch.nix
+#
+# Accepts a list of policies — each an attrset pairing a match predicate with an action:
+#
+#   runIf  : bool | (ctx -> bool)    match predicate;   default: true  (always match)
+#   runFn  : inputs -> path -> a     loader thunk to invoke;  default: loaders.scoped
+#   logIf  : bool | (ctx -> bool)    enable tracing;    default: false
+#   logPfx : string                  trace prefix;      default: "[dispatch]"
+#   logSfx : string                  trace suffix note; default: ""n
+#
+# ctx is: { path, inputs }
+# Policies are evaluated in order — first match wins, action is invoked.
+# The action (runFn) is never called until its policy is selected.
+
+{ lib, ... }@fnArgs:
+policies:
+let
+  default = {
+    # if no runIf condition is provided, default to match. This helps minimize boilerplate.
+    runIf = true;
+    runFn = fnArgs.loaders.scoped;
+    logIf = false;
+    logFn = builtins.trace;
+    logPfx = "[L] :dispatch:\t";
+    logSep = " ";
+    logFmt =
+      ctx:
+      [
+        "${ctx.logPfx}"
+        "path=${ctx.path}"
+        "runIf=${if ctx.runIf then "true" else "false"}"
+        "type=${builtins.typeOf ctx.result}"
+      ]
+      ++ (if ctx.logSfx != "" then [ "\t -- ${ctx.logSfx}" ] else [ ]);
+    logSfx = "";
+  };
+  evalPred =
+    pred: ctx:
+    if builtins.isBool pred then
+      pred
+    else if builtins.isFunction pred then
+      (pred ctx) == true
+    else
+      false;
+
+  firstMatch =
+    ctx: remaining:
+    if remaining == [ ] then
+      builtins.throw "${default.logPfx} disjoint policies - no policy match found for path '${ctx.path}'"
+    else
+      let
+        policy = builtins.head remaining;
+      in
+      if evalPred (policy.runIf or default.runIf) ctx then
+        policy
+      else
+        firstMatch ctx (builtins.tail remaining);
+in
+inputs: path:
+let
+  ctx = {
+    inherit
+      policy
+      path
+      inputs
+      result
+      runIf
+      runFn
+      logIf
+      logFn
+      logPfx
+      logSfx
+      logSep
+      logFmt
+      ;
+  };
+  # Limit the info available during firstMatch to prevent infinite recursion.
+  matchCtx = { inherit path inputs; };
+  policy = firstMatch matchCtx policies;
+  result = runFn inputs path;
+  runIf = evalPred (if policy ? runIf then policy.runIf else default.runIf) ctx; # render runIf to bool
+  logIf = evalPred (
+    if policy ? logIf then
+      policy.logIf
+    else if default ? logIf then
+      default.logIf
+    else
+      policy.runIf
+  ) ctx; # render logIf to bool, default: trace only on runIf
+  runFn = policy.runFn or default.runFn or (throw "${logPfx} no loader (or default loader) provided");
+  logFn = policy.logFn or default.logFn;
+  logPfx = policy.logPfx or default.logPfx;
+  logSfx = policy.logSfx or default.logSfx;
+  logSep = policy.logSep or default.logSep;
+  logFmt = policy.logFmt or default.logFmt;
+  logMsg = builtins.concatStringsSep logSep (logFmt ctx);
+in
+if logIf then logFn logMsg result else result

--- a/src/loaders/scopedPartsPerSystem.nix
+++ b/src/loaders/scopedPartsPerSystem.nix
@@ -1,0 +1,7 @@
+# loaders/scopedPartsPerSystem.nix
+{ ... }:
+inputs: path: newCtx:
+let
+  imported = builtins.scopedImport (inputs // newCtx) path;
+in
+if builtins.isFunction imported then imported newCtx else imported

--- a/src/transformers/liftDefaultPartsPerSystem.nix
+++ b/src/transformers/liftDefaultPartsPerSystem.nix
@@ -1,0 +1,19 @@
+# transformers/liftDefaultPartsPerSystem.nix
+{ ... }:
+cursor: mod:
+if builtins.isAttrs mod && mod ? default then
+  let
+    siblings = builtins.removeAttrs mod [ "default" ];
+    hoisted = mod.default;
+  in
+  if siblings == { } then
+    hoisted
+  else
+  # If the hoisted default is a deferred function (from scopedPartial),
+  # we must defer the merge until flake-parts provides the args.
+  if builtins.isFunction hoisted then
+    args: siblings // (hoisted args)
+  else
+    siblings // hoisted
+else
+  mod

--- a/src/transformers/match.nix
+++ b/src/transformers/match.nix
@@ -1,0 +1,53 @@
+# transformers/match.nix
+# Note:
+# - the predicate (abbrv. "logIf") allows shipping a function or boolean value into the execution context.
+# - If 'logIf' evals true, the trace log will emit. If not it will proceed normally, but without emitting a trace event.
+# - The default value of 'logIf' is boolean false.
+# - Using 'logIf' and 'logSfx' should allow for emitting simple trace messages only when certain watched conditions are encountered in the execution context.
+# - If used (carefully), a custom 'logFmt' can also get supplemental diagnostic info from the execution context.
+# - To perform only tracing, use the trace transformer instead of this.
+{ super, ... }@fnArgs:
+ctx: innerFunc: cursor: mod:
+let
+  fullCtx =
+    fnArgs
+    // ctx
+    // {
+      inherit
+        innerFunc
+        cursor
+        mod
+        typeOf
+        runIf
+        logIf
+        ;
+    };
+  default = {
+    runIf = true;
+    logIf = false;
+    logPfx = "[T] :match:\t";
+  };
+  simplify = part: ctx: if builtins.isFunction part then (part ctx) else part;
+  evalPred = pred: ctx: (simplify pred ctx) == true;
+  ##
+  typeOf = builtins.typeOf mod;
+  runIf = evalPred (if ctx ? runIf then ctx.runIf else default.runIf) fullCtx; # render runIf to bool
+  logIf = evalPred (
+    if ctx ? logIf then
+      ctx.logIf
+    else if default ? logIf then
+      default.logIf
+    else
+      runIf
+  ) ctx; # render logIf to bool, default: trace only on runIf
+  logFn = data: super.trace fullCtx cursor data;
+  logFnBefore = logFn mod;
+  logFnAfter = logFn result;
+  result = innerFunc cursor mod;
+in
+if logIf && runIf then
+  logFnAfter
+else if runIf then
+  result
+else
+  logFnBefore

--- a/src/transformers/trace.nix
+++ b/src/transformers/trace.nix
@@ -1,0 +1,65 @@
+# transformers/trace.nix
+# Note:
+# - the predicate (abbrv. "logIf") allows shipping a function or boolean value into the execution context.
+# - If 'logIf' evals true, the trace log will emit. If not it will proceed normally, but without emitting a trace event.
+# - The default value of 'logIf' is boolean true.
+# - Using 'logIf' and 'logSfx' should allow for emitting trace messages only when certain watched conditions are true within the execution context.
+# - If used (carefully), a custom 'logFmt' can also get supplemental diagnostic info from the execution context.
+# - To perform a conditional transform, use the match transformer instead of this.
+{ ... }@fnArgs:
+ctx: cursor: mod:
+let
+  fullCtx =
+    fnArgs
+    // ctx
+    // {
+      inherit
+        cursor
+        mod
+        typeOf
+        keys
+        runIf
+        logIf
+        logPfx
+        logSep
+        logSfx
+        logFmt
+        ;
+    };
+  default = {
+    logIf = true;
+    logPfx = "[T] :trace:\t";
+    logSep = " ";
+    logFmt =
+      ctx:
+      [
+        "${ctx.logPfx}"
+        "cursor=${builtins.toJSON ctx.cursor}"
+        "runIf=${builtins.toJSON ctx.runIf}"
+        "type=${ctx.typeOf}"
+      ]
+      ++ (if builtins.isString ctx.logSfx && ctx.logSfx != "" then [ "\t-- ${ctx.logSfx}" ] else [ ]);
+    logSfx = "";
+  };
+  simplify = part: ctx: if builtins.isFunction part then (part ctx) else part;
+  evalPred = pred: ctx: (simplify pred ctx) == true;
+  ##
+  typeOf = builtins.typeOf mod;
+  keys = if builtins.isAttrs mod then builtins.toJSON (builtins.attrNames mod) else "N/A";
+  ##
+  runIf = if ctx ? runIf then ctx.runIf else null;
+  logIf = evalPred (
+    if ctx ? logIf then
+      ctx.logIf
+    else if default ? logIf then
+      default.logIf
+    else
+      runIf
+  ) fullCtx;
+  logPfx = if ctx ? logPfx then ctx.logPfx else default.logPfx;
+  logSep = if ctx ? logSep then ctx.logSep else default.logSep;
+  logSfx = if ctx ? logSfx then ctx.logSfx else default.logSfx;
+  logFmt = simplify (if ctx ? logFmt then ctx.logFmt else default.logFmt) fullCtx;
+  logMsg = builtins.concatStringsSep logSep logFmt;
+in
+if logIf then builtins.trace logMsg mod else mod

--- a/src/transformers/wrapPartsPerSystem.nix
+++ b/src/transformers/wrapPartsPerSystem.nix
@@ -1,0 +1,49 @@
+# transformers/wrapPartsPerSystem.nix
+{ ... }:
+cursor: mod:
+let
+  # ===========================================================================
+  # LAZY STRUCTURAL MAPPER
+  # ===========================================================================
+  # This recursively maps over the Haumea tree. Because builtins.mapAttrs
+  # is lazy, `lazyWrap child args` becomes a thunk. It will not evaluate
+  # until flake-parts explicitly accesses that specific key in the tree.
+  lazyWrap =
+    node: args:
+    let
+      # 1. EVALUATE PARTIAL: Only triggered when this specific node is accessed
+      resolved = if builtins.isFunction node then node args else node;
+    in
+    # 2. RECURSE: If it's a standard attrset, lazily map its children.
+    # We check for the "derivation" type to prevent infinite recursion into compiled packages.
+    if builtins.isAttrs resolved && !(resolved ? type && resolved.type == "derivation") then
+      builtins.mapAttrs (_: child: lazyWrap child args) resolved
+
+    # 3. BASE CASE: Return the resolved leaf (package, string, list, etc.)
+    else
+      resolved;
+
+  # ===========================================================================
+  # THE TOP-LEVEL THUNK
+  # ===========================================================================
+  # We return a single module function to flake-parts.
+  # When flake-parts evaluates `perSystem`, it calls this function, injecting { pkgs, system, ... }
+  haumeaPartsPerSystemResolverTree =
+    {
+      pkgs,
+      lib,
+      system,
+      inputs',
+      self',
+      config,
+      ...
+    }@perSystemArgs:
+    lazyWrap mod perSystemArgs;
+
+in
+if cursor == [ "perSystem" ] then
+  {
+    imports = [ haumeaPartsPerSystemResolverTree ];
+  }
+else
+  mod


### PR DESCRIPTION
### BLUF
For those who are interested in using Flake-Parts fed with Haumea - it's now elegantly supported.

### Intro
Haumea and flake-parts are both compelling ways to represent, organize, and leverage declarative configs.
It's always been possible to use them together if the `perSystem` was excluded, but this PR now closes that gap, so that an entire config can be provided to `mkFlake` by haumea.
 
I've keenly wanted this for me own uses.

This unlocks my preferred design for a (Dendritic-adjacent) semantically structural, flake -forward approach.

### Benefits
This makes it possible to produce minimal and infrequently changing flake.nix files.

### Usage Example
Here's the operative snippet from the flake.nix file:
```
  ##<outputs>##
  outputs = {self, ...} @ inputs:
    inputs.parts.lib.mkFlake {inherit inputs;} (
      inputs.haumea.lib.load {
        src = ./_attrs;
        inputs = {inherit inputs;};
        # loader operates as a first match wins system
        # loader-fns are passed: attrs, inputs, path
        loader =
          inputs.haumea.lib.loaders.dispatch
          [
            # handle the perSystem case w/ a special loader before the general case
            {
              logSfx = "case|perSystem => scoped";
              runIf = ctx:
                builtins.match ".*(/|\.nix)$" (builtins.toString ctx.path)
                != null
                && builtins.match ".*/perSystem/.*" (builtins.toString ctx.path) != null;
              runFn = inputs.haumea.lib.loaders.scopedPartsPerSystem;
            }
            # handle the general case w/ a normal loader
            {
              logSfx = "case|general => scoped";
              runFn = inputs.haumea.lib.loaders.scoped;
            }
          ];
        # transformers operate as an assembly line of sequential potential modifications
        transformer = [
          #(inputs.haumea.lib.transformers.trace {})
          (inputs.haumea.lib.transformers.match
            {
              logSfx = "case|perSystem => liftDefault";
              runIf = ctx: builtins.elem "perSystem" ctx.cursor;
            }
            inputs.haumea.lib.transformers.liftDefaultPartsPerSystem)
          (inputs.haumea.lib.transformers.match
            {
              logSfx = "case|general => liftDefault";
              runIf = ctx: !(builtins.elem "perSystem" ctx.cursor);
            }
            inputs.haumea.lib.transformers.liftDefault)
          (inputs.haumea.lib.transformers.match
            {
              logSfx = "case|perSystem => wrapPartsPerSystem";
              runIf = ctx: ctx.cursor == ["perSystem"];
            }
            inputs.haumea.lib.transformers.wrapPartsPerSystem)
        ];
      }
    );
  ##</outputs>##
```

### Considerations

It's possible and valid to wrap this in a bit of syntactic sugar, but wanted to show a working example built from minimal, (largely repurpose-able) functionality.

The final form was more verbose than the goal I'd initially imagined, but is also more flexible, with the introduction of a dispatch loader, and match-action transformer.

Nearly half of this PR relates to expanding control flow and logging. 

For the specific integration with flake-parts, eg. with scopedPartsPerSystem.nix,  we're wrapping scoped imports in a lambda to be provided by smuggled through haumea into the flake-parts module system where it's re-ydrated when executed as module function.

Even this may be generally useful more broadly than only with flake-parts, and I've made an effort to distinguish between what's intended to use with flake-parts and what may be more broadly applied.


### Next

I'm interested it getting this added upstream. I'm happy to take a list of changes and adjustments to help that happen. Please let me know if that's possible and advisable. 
Thanks!


_[Disclosure]_ Claude was used to break through some misunderstandings and hurdles.
