### PR TITLE
Rename nixpkgs input to nixpkgs-lib

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ lib ? import <nixpkgs/lib> }:
+{ lib ? import <nixpkgs-lib/lib> }:
 
 let
   load = import ./src/load.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Filesystem-based module system for Nix";
 
   inputs = {
-    nixpkgs.url = "github:nix-community/nixpkgs.lib";
+    nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
   };
 
   outputs = { self, nixpkgs }: {

--- a/flake.nix
+++ b/flake.nix
@@ -5,16 +5,16 @@
     nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
   };
 
-  outputs = { self, nixpkgs }: {
+  outputs = { self, nixpkgs-lib }: {
     checks = self.lib.loadEvalTests {
       src = ./tests;
       inputs = {
-        inherit (nixpkgs) lib;
+        inherit (nixpkgs-lib) lib;
         haumea = self.lib;
       };
     };
     lib = import self {
-      inherit (nixpkgs) lib;
+      inherit (nixpkgs-lib) lib;
     };
     templates = {
       default = {

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -5,10 +5,9 @@
       inputs.nixpkgs-lib.follows = "nixpkgs-lib";
     };
     nixpkgs-lib.url = "github:nix-community/nixpkgs.url";
-nixpkgs.url = "github:NixOS/nixpkgs-unstable";
   };
 
-  outputs = { self, haumea, nixpkgs }: {
+  outputs = { self, haumea, nixpkgs-lib }: {
     checks = haumea.lib.loadEvalTests {
       src = ./tests;
       inputs = {

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -2,23 +2,24 @@
   inputs = {
     haumea = {
       url = "github:nix-community/haumea/v0.2.2";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs-lib.follows = "nixpkgs-lib";
     };
-    nixpkgs.url = "github:nix-community/nixpkgs.lib";
+    nixpkgs-lib.url = "github:nix-community/nixpkgs.url";
+nixpkgs.url = "github:NixOS/nixpkgs-unstable";
   };
 
   outputs = { self, haumea, nixpkgs }: {
     checks = haumea.lib.loadEvalTests {
       src = ./tests;
       inputs = {
-        inherit (nixpkgs) lib;
+        inherit (nixpkgs-lib) lib;
         foo = self.lib;
       };
     };
     lib = haumea.lib.load {
       src = ./src;
       inputs = {
-        inherit (nixpkgs) lib;
+        inherit (nixpkgs-lib) lib;
       };
     };
   };


### PR DESCRIPTION
#Reasons for being nitpicky?
1. flake-parts already does this so its not unusual.
2. Since its what you're actually using internally, its probably best to rename the input to reflect what that. 
3. Most important, if a downstream user sees a nixpkgs input for haumea, and does inputs.haumea.follows = nixpkgs; without realizing the input here, that adds pkgs back into scope?

That's really... really bad when using super, root, and self especially; could result in infinite recursion, and users accidentally building packages; by trying to follow best practice...  While inputs.nixpkgs-lib.follows does nothing.